### PR TITLE
.golangci.yml updated for go1.22

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,9 +4,11 @@ run:
   build-tags:
     - integration
   modules-download-mode: readonly
-  go: '1.17'
+  go: '1.22'
 output:
-  format: tab:lint.txt
+  formats:
+  - format: tab
+    path: lint.txt
   print-issued-lines: false
   uniq-by-line: false
   sort-results: true

--- a/simulator/internal/simulator/simulator.go
+++ b/simulator/internal/simulator/simulator.go
@@ -71,7 +71,6 @@ func (s Simulator) Simulate() error {
 		}
 
 		for _, p := range policies {
-			p := p
 			capacity := capacity
 			eg.Go(func() error {
 				return s.simulatePolicy(p, capacity)


### PR DESCRIPTION
Fixed lint issues, upgrade to `go1.22` which included this error:

```
# Before upgrade to 1.22
level=warning msg="[config_reader] The configuration option `output.format` is deprecated, please use `output.formats`"
level=warning msg="[linters_context] copyloopvar: this linter is disabled because the Go version (1.17) of your project is lower than Go 1.22"

# after upgrade to 1.22
simulator/internal/simulator/simulator.go:74:4  copyloopvar  The copy of the 'for' variable "p" can be deleted (Go 1.22+)
```